### PR TITLE
Исправление для проговаривания цифр из лога

### DIFF
--- a/EliteVoice/ConfigReader/Commands/TextCommand.cs
+++ b/EliteVoice/ConfigReader/Commands/TextCommand.cs
@@ -19,8 +19,7 @@ namespace EliteVoice.ConfigReader.Commands
                 string parameter = getProperties()["select"];
                 if (parameters.ContainsKey(parameter))
                 {
-//                  text = (string)parameters[parameter];
-                    text = string.Format("{0:N2}",parameters[parameter]);
+                    text = string.Format("{0:#,##}",parameters[parameter]);
                 }
             }
             else if (getProperties().ContainsKey("@text"))

--- a/EliteVoice/ConfigReader/Commands/TextCommand.cs
+++ b/EliteVoice/ConfigReader/Commands/TextCommand.cs
@@ -19,7 +19,7 @@ namespace EliteVoice.ConfigReader.Commands
                 string parameter = getProperties()["select"];
                 if (parameters.ContainsKey(parameter))
                 {
-                    text = string.Format("{0:0,##}",parameters[parameter]);
+                    text = string.Format("{0:#,##}",parameters[parameter]);
                 }
             }
             else if (getProperties().ContainsKey("@text"))

--- a/EliteVoice/ConfigReader/Commands/TextCommand.cs
+++ b/EliteVoice/ConfigReader/Commands/TextCommand.cs
@@ -19,7 +19,7 @@ namespace EliteVoice.ConfigReader.Commands
                 string parameter = getProperties()["select"];
                 if (parameters.ContainsKey(parameter))
                 {
-                    text = string.Format("{0:#,##}",parameters[parameter]);
+                    text = string.Format("{0:0,##}",parameters[parameter]);
                 }
             }
             else if (getProperties().ContainsKey("@text"))

--- a/EliteVoice/ConfigReader/Commands/TextCommand.cs
+++ b/EliteVoice/ConfigReader/Commands/TextCommand.cs
@@ -19,7 +19,8 @@ namespace EliteVoice.ConfigReader.Commands
                 string parameter = getProperties()["select"];
                 if (parameters.ContainsKey(parameter))
                 {
-                    text = (string)parameters[parameter];
+//                  text = (string)parameters[parameter];
+                    text = string.Format("{0:N2}",parameters[parameter]);
                 }
             }
             else if (getProperties().ContainsKey("@text"))

--- a/EliteVoice/EliteVoice.csproj
+++ b/EliteVoice/EliteVoice.csproj
@@ -90,14 +90,17 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NAudio">
-      <HintPath>F:\freelance\elite-dangerous\NAudio-Release\NAudio.dll</HintPath>
+    <Reference Include="NAudio, Version=1.7.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\NAudio.1.7.3\lib\net35\NAudio.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="NAudio.WindowsMediaFormat">
-      <HintPath>F:\freelance\elite-dangerous\NAudio-Release\NAudio.WindowsMediaFormat.dll</HintPath>
+    <Reference Include="NAudio.WindowsMediaFormat, Version=1.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\NAudio.Wma.1.0.1\lib\net35\NAudio.WindowsMediaFormat.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>F:\freelance\elite-dangerous\json.net\Bin\Net35\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -174,6 +177,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/EliteVoice/packages.config
+++ b/EliteVoice/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NAudio" version="1.7.3" targetFramework="net452" />
+  <package id="NAudio.Wma" version="1.0.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
Корректно проговаривает события вида:
{ "timestamp":"2016-10-31T13:06:55Z", "event":"DockingGranted", "LandingPad":**10**, "StationName":"Coleman Gateway" }
описанные в конфиге:
`<Event name="DockingGranted">
   <TextToSpeech>
      <Text>Стыковка с</Text>
      <Text select="StationName"/>
      <Text>разрешена.</Text>
      <Text>Посадочное место номер:</Text>
      <Text select="LandingPad"/>
   </TextToSpeech>
</Event>`